### PR TITLE
Adding installation of java JDK 11 to vagrant file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,8 @@
+pipeline {
+    agent any
+    stages {
+        stage('test'){
+            echo "Hello!.."
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,9 @@ pipeline {
     agent any
     stages {
         stage('test'){
-            echo "Hello!.."
+            steps{
+                echo "Hello!.."
+            }          
         }
     }
 }

--- a/Vagrant_Compose/Vagrantfile
+++ b/Vagrant_Compose/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
     curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > "/dev/null"
     apt update && apt upgrade -y
-    apt install docker-ce docker-ce-cli containerd.io docker-compose -y
+    apt install docker-ce docker-ce-cli containerd.io docker-compose openjdk-11-jdk -y
     mkdir /ATDockerLT
     cd /ATDockerLT
     git clone https://github.com/zkpain/ATDockerLT.git


### PR DESCRIPTION
Adding the java JDK 11 installation for the vagrant file on the provisioner part, in order to don't have issues with Jenkins